### PR TITLE
Don't overwrite parent storext options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBA
+
+- Fix: if a subclass invokes `include Storext::Override` the `storext_options` inherited from the parent is not wiped out
+
 # 0.3.0
 
 - Add `:ignore_override_if_blank` option

--- a/lib/storext/override.rb
+++ b/lib/storext/override.rb
@@ -6,7 +6,7 @@ module Storext
     extend ActiveSupport::Concern
 
     included do
-      include Storext.model
+      include Storext.model unless self.respond_to? :storext_options
     end
 
     def storext_override_discard_value?(attr)

--- a/spec/dummy/app/models/komputer.rb
+++ b/spec/dummy/app/models/komputer.rb
@@ -1,7 +1,7 @@
 class Komputer < ActiveRecord::Base
   self.table_name = "computers"
   store :data, coder: JSON
-  include Storext.model
+  include Storext.model(options: { some: :options })
 
   store_attributes :data do
     manufacturer String, default: "IBM"

--- a/spec/dummy/app/models/super_komputer.rb
+++ b/spec/dummy/app/models/super_komputer.rb
@@ -1,0 +1,3 @@
+class SuperKomputer < Komputer
+  include Storext::Override
+end

--- a/spec/dummy/db/migrate/20160210065853_add_options_to_computers.rb
+++ b/spec/dummy/db/migrate/20160210065853_add_options_to_computers.rb
@@ -1,0 +1,5 @@
+class AddOptionsToComputers < ActiveRecord::Migration
+  def change
+    add_column :computers, :options, :text
+  end
+end

--- a/spec/dummy/db/migrate/20160210071144_add_type_to_computers.rb
+++ b/spec/dummy/db/migrate/20160210071144_add_type_to_computers.rb
@@ -1,0 +1,5 @@
+class AddTypeToComputers < ActiveRecord::Migration
+  def change
+    add_column :computers, :type, :text
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,12 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150818085353) do
+ActiveRecord::Schema.define(version: 20160210071144) do
 
   create_table "computers", force: :cascade do |t|
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "options"
+    t.text     "type"
   end
 
   create_table "phones", force: :cascade do |t|

--- a/spec/storext/override_spec.rb
+++ b/spec/storext/override_spec.rb
@@ -11,6 +11,12 @@ describe Storext::Override do
     { ignore_override_if_blank: ignore_override_if_blank }
   end
 
+  describe 'inclusion' do
+    it 'does not overwrite storext_options set in the parent' do
+      expect(SuperKomputer.new.options).to eq({ some: :options }.to_s)
+    end
+  end
+
   describe '.storext_override' do
     let(:ignore_override_if_blank) { true }
 


### PR DESCRIPTION
when subclass invokes `include Storext::Override`
