### PR TITLE
False values should not be ignored when saving

### DIFF
--- a/lib/storext/override.rb
+++ b/lib/storext/override.rb
@@ -11,6 +11,7 @@ module Storext
 
     def storext_override_discard_value?(attr)
       send(:"#{attr}_without_parent_default").blank? &&
+        send(:"#{attr}_without_parent_default") != false &&
         self.class.override_options[:ignore_override_if_blank]
     end
 

--- a/spec/dummy/app/models/komputer.rb
+++ b/spec/dummy/app/models/komputer.rb
@@ -5,5 +5,6 @@ class Komputer < ActiveRecord::Base
 
   store_attributes :data do
     manufacturer String, default: "IBM"
+    manufactured Boolean, default: true
   end
 end

--- a/spec/storext/override_spec.rb
+++ b/spec/storext/override_spec.rb
@@ -43,7 +43,9 @@ describe Storext::Override do
     before do
       phone.update_attributes(
         manufacturer: phone_manufacturer,
-        override_manufacturer: true
+        override_manufacturer: true,
+        manufactured: false,
+        override_manufactured: true,
       )
     end
 
@@ -53,6 +55,10 @@ describe Storext::Override do
       it do
         expect(phone.manufacturer).to eq computer.manufacturer
       end
+
+      it "does not delete keys with false boolean data" do
+        expect(phone.manufactured).to eq false
+      end
     end
 
     context 'ignore_override_if_blank is false' do
@@ -60,6 +66,10 @@ describe Storext::Override do
 
       it do
         expect(phone.manufacturer).to eq phone_manufacturer
+      end
+
+      it "does not delete keys with false boolean data" do
+        expect(phone.manufactured).to eq false
       end
     end
   end


### PR DESCRIPTION
This is specially important when trying to override Boolean values
with a default true value. Previously, false values would be ignored
and not saved. This commit fixes that.